### PR TITLE
Adds pre-commit to the CI.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,10 +16,10 @@ jobs:
   # run the pre-commit linters and code tidyup
   linter:
     runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
 
 
   # install the package and run the tests


### PR DESCRIPTION
I use a tool called [pre-commit](https://pre-commit.com) to automatically add linters before committing. Annoyingly/confusingly the name of the tool is "pre-commit", but [git pre-commit hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are a general thing that existed before. So pre-commit (the tool) adds git pre-commit hooks.

Currently, [it's mostly linters and python code style](https://github.com/samcunliffe/cavendish-particle-tracks/blob/main/.pre-commit-config.yaml). This PR adds [the official pre-commit action](https://github.com/pre-commit/action) with that config to the CI.

If you want to add them too...

```
$ pip install pre-commit
$ pre-commit install # optional
# you should see something like:  pre-commit installed at .git/hooks/pre-commit
$ ls  .git/hooks/pre-commit # to check
```

Now when you try to commit something it checks your python style (and usually fixes it) before it lets you commit. If you don't want it to interrupt your commits you can not run `pre-commit install` and just use `pre-commit run` whenever you're ready to commit.