### PR TITLE
Temporarily reduce test matrix.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        platform: [ubuntu-latest] #, windows-latest, macos-latest]
+        python-version: ['3.10'] # ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We're doing 3 OS × 3 python versions = 9 build tests. Let's just do a 1×1 "matrix" for now.

We can revert this before making the repo public when we're further down and into UX improvements.