### PR TITLE
Reverting napari 0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "napari",
+    "napari>=0.4.18, <0.5.0",
     "numpy",
     # magicgui
     "qtpy",

--- a/src/cavendish_particle_tracks/_analysis.py
+++ b/src/cavendish_particle_tracks/_analysis.py
@@ -20,6 +20,8 @@ FIDUCIAL_BACK = {
 }  # cm
 
 EXPECTED_PARTICLES = ["New particle", "Σ+", "Σ-", "Λ0"]
+FIDUCIALS = ["New Fiducial, A, A', B, B', C, C', D, D', E, F, F'"]
+# TODO: This needs to be updated to merge the marking of the fiducials here with the calculated values in the analysis.
 
 
 @dataclass

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -149,9 +149,6 @@ class StereoshiftDialog(QDialog):
             "translation": np.array([-30, 0]),
         }
 
-        # create a points layer where the face_color is set by the good_point feature
-        # and the edge_color is set via a color map (grayscale) on the confidence
-        # feature.
         points_layer = self.parent.viewer.add_points(
             points,
             name="Points_Stereoshift",
@@ -162,9 +159,6 @@ class StereoshiftDialog(QDialog):
             border_color=colors,
             face_color=colors,
         )
-
-        # set the edge_color mode to colormap
-        # points_layer.edge_color_mode = 'colormap'
 
         return points_layer
 

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -15,18 +15,26 @@ from ._calculate import depth, length, stereoshift
 
 class StereoshiftDialog(QDialog):
     def __init__(self, parent=None):
+        # Call parent constructor
         super().__init__(parent)
 
+        # Declare instance variables + constants
         self.parent = parent
-
-        self.setWindowTitle("Stereoshift")
-
         FIDUCIAL_VIEWS = [
             "Back fiducial view1",
             "Back fiducial view2",
             "Point view1",
             "Point view2",
         ]
+        # Stereoshift related parameters
+        self.shift_fiducial = 0.0
+        self.shift_point = 0.0
+        self.point_stereoshift = 0.0
+        self.point_depth = -1.0
+        self.spoints = []
+
+        # region UI Setup
+        self.setWindowTitle("Stereoshift")
         self._fiducial_views = [
             Fiducial(view_name) for view_name in FIDUCIAL_VIEWS
         ]
@@ -110,16 +118,10 @@ class StereoshiftDialog(QDialog):
         self.layout().addWidget(self.tdepth, 12, 2)
         self.layout().addWidget(bap, 13, 0, 1, 3)
         self.layout().addWidget(self.buttonBox, 14, 0, 1, 3)
+        # endregion
 
-        # Setup points layer
+        # Setup points layer with stereoshift markers
         self.cal_layer = self._setup_stereoshift_layer()
-
-        # Stereoshift related parameters
-        self.shift_fiducial = 0.0
-        self.shift_point = 0.0
-        self.point_stereoshift = 0.0
-        self.point_depth = -1.0
-        self.spoints = []
 
     def _setup_stereoshift_layer(self):
         # add the points

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -154,9 +154,9 @@ class StereoshiftDialog(QDialog):
             name="Points_Stereoshift",
             text=text,
             size=20,
-            border_width=7,
-            border_width_is_relative=False,
-            border_color=colors,
+            edge_width=7,
+            edge_width_is_relative=False,
+            edge_color=colors,
             face_color=colors,
         )
 

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -402,10 +402,27 @@ class ParticleTracksWidget(QWidget):
         # currently, this is implemented by adding the layer, then a point.
         # ideally this should resemble the inbuilt tools, but let's get it working first.
 
-        # I want to look at setup_stereoshift_layer in _stereoshift_dialog.py
-        point = [
-            100,
-            100,
-        ]  # this should be done properly later, currently copying the old approach
-
+        point = [100, 100]
+        # this should be done properly later, currently copying the old approach
+        # get below to reference the currently selected fiducial in the combobox
+        name = "Example C'"
+        point_label = {
+            "string": name,
+            "size": 20,
+            "color": "green",
+            "translation": np.array([-30, 0]),
+        }
+        # see stereoshift_dialog
+        # create a points layer here if one doesn't exist.
+        # reuse code from other sections here to achieve that.
+        points_layer = self.parent.viewer.add_point(
+            point,
+            name="Fiducials",
+            # text=...
+            # size=20,
+            border_width=5,
+            # border_width_is_relative=True,
+            # border_color=colors,
+            # face_color=colors,
+        )
         print("This is a placeholder function.")

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -26,6 +26,7 @@ from qtpy.QtWidgets import (
 
 from ._analysis import (
     EXPECTED_PARTICLES,
+    FIDUCIALS,
     NewParticle,
 )
 from ._calculate import length, radius
@@ -42,16 +43,20 @@ class ParticleTracksWidget(QWidget):
         self.viewer = napari_viewer
 
         # define QtWidgets
+        # why is this self. and the others added after?
         self.cb = QComboBox()
         self.cb.addItems(EXPECTED_PARTICLES)
         self.cb.setCurrentIndex(0)
         self.cb.currentIndexChanged.connect(self._on_click_new_particle)
-        rad = QPushButton("Calculate radius")
-        lgth = QPushButton("Calculate length")
-        ang = QPushButton("Calculate decay angles")
-        stsh = QPushButton("Stereoshift")
+        btn_radius = QPushButton("Calculate radius")
+        btn_length = QPushButton("Calculate length")
+        btn_decayangle = QPushButton("Calculate decay angles")
+        cmb_fiducial = QComboBox()
+        cmb_fiducial.addItems(FIDUCIALS)
+        cmb_fiducial.currentIndexChanged.connect(self._on_click_add_fiducial)
+        btn_stereoshift = QPushButton("Stereoshift")
+        btn_save = QPushButton("Save")
         self.mag = QPushButton("Magnification")
-        save = QPushButton("Save")
 
         # setup particle table
         self.table = self._set_up_table()
@@ -62,12 +67,13 @@ class ParticleTracksWidget(QWidget):
         self.cal.setEnabled(False)
 
         # connect callbacks
-        rad.clicked.connect(self._on_click_radius)
-        lgth.clicked.connect(self._on_click_length)
-        ang.clicked.connect(self._on_click_decay_angles)
-        stsh.clicked.connect(self._on_click_stereoshift)
+        # NOTE: This isn't consistent in the code structure. Connects for the combobox etc have been done above.
+        btn_radius.clicked.connect(self._on_click_radius)
+        btn_length.clicked.connect(self._on_click_length)
+        btn_decayangle.clicked.connect(self._on_click_decay_angles)
+        btn_stereoshift.clicked.connect(self._on_click_stereoshift)
         self.cal.toggled.connect(self._on_click_apply_magnification)
-        save.clicked.connect(self._on_click_save)
+        btn_save.clicked.connect(self._on_click_save)
 
         self.mag.clicked.connect(self._on_click_magnification)
         # TODO: find which of thsese works
@@ -78,14 +84,15 @@ class ParticleTracksWidget(QWidget):
         # layout
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.cb)
-        self.layout().addWidget(rad)
-        self.layout().addWidget(lgth)
-        self.layout().addWidget(ang)
+        self.layout().addWidget(btn_radius)
+        self.layout().addWidget(btn_length)
+        self.layout().addWidget(btn_decayangle)
         self.layout().addWidget(self.table)
         self.layout().addWidget(self.cal)
-        self.layout().addWidget(stsh)
+        self.layout().addWidget(btn_stereoshift)
         self.layout().addWidget(self.mag)
-        self.layout().addWidget(save)
+        self.layout().addWidget(cmb_fiducial)
+        self.layout().addWidget(btn_save)
 
         # Data analysis
         self.data: List[NewParticle] = []
@@ -389,3 +396,16 @@ class ParticleTracksWidget(QWidget):
             f.writelines([particle.to_csv() for particle in self.data])
 
         print("Saved data to ", filename)
+
+    def _on_click_add_fiducial(self) -> None:
+        """Adds a fiducial marker to the layer."""
+        # currently, this is implemented by adding the layer, then a point.
+        # ideally this should resemble the inbuilt tools, but let's get it working first.
+
+        # I want to look at setup_stereoshift_layer in _stereoshift_dialog.py
+        point = [
+            100,
+            100,
+        ]  # this should be done properly later, currently copying the old approach
+
+        print("This is a placeholder function.")


### PR DESCRIPTION
The feature `Open Files as Stack` does not seem to work from napari 0.5.0 onwards. This feature is needed for the data loading (#48).

Here we revert to `napari>=4.0.18, <0.5.0` and revert some of @Joseph-Garvey 's changes (#54) as they break in these versions.
