### PR TITLE
Reverting napari version to 0.4.18/19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "napari",
+    "napari>=0.4.18, <0.5.0",
     "numpy",
     # magicgui
     "qtpy",

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -155,9 +155,9 @@ class StereoshiftDialog(QDialog):
             name="Points_Stereoshift",
             text=text,
             size=20,
-            border_width=7,
-            border_width_is_relative=False,
-            border_color=colors,
+            edge_width=7,
+            edge_width_is_relative=False,
+            edge_color=colors,
             face_color=colors,
         )
 


### PR DESCRIPTION
The feature `Open Files as Stack` does not seem to work from napari 0.5.0 onwards. This feature is needed for the data loading (#48).

Here we revert to napari>=4.0.18, <0.5.0 and revert some of @Joseph-Garvey 's changes (https://github.com/palvarezc/cavendish-particle-tracks/pull/54) as they break in these versions.