### PR TITLE
Reenable tests on MacOS.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest] #, windows-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11'] # ['3.8']
 
     steps:


### PR DESCRIPTION
Now that the repo is open source, there's no reason not to run MacOS tests. You can also add Windows tests if you really must.