### PR TITLE
Add pytest fixture to set up the `ParticleTracksWidget`.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from cavendish_particle_tracks._widget import ParticleTracksWidget
+
+
+@pytest.fixture
+def cpt_widget(make_napari_viewer):
+    """Common test setup fixture: calls the napari helper fixture
+    `make_napari_viewer` then creates the ParticleTracksWidget."""
+    viewer = make_napari_viewer()
+    widget = ParticleTracksWidget(napari_viewer=viewer)
+    return widget

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -1,11 +1,9 @@
 from cavendish_particle_tracks._decay_angles_dialog import DecayAnglesDialog
-from cavendish_particle_tracks._widget import ParticleTracksWidget
 
 
-def test_decay_angles_dialog(make_napari_viewer, qtbot):
+def test_decay_angles_dialog(cpt_widget, qtbot):
     """Smoke test for the DecayAnglesDialog."""
-    my_widget = ParticleTracksWidget(make_napari_viewer())
-    dialog = DecayAnglesDialog(parent=my_widget)
+    dialog = DecayAnglesDialog(parent=cpt_widget)
     qtbot.addWidget(dialog)
 
     # show dialog and check that it closes

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,33 +1,26 @@
 from glob import glob
 from os import chdir, stat
 
-from cavendish_particle_tracks import ParticleTracksWidget
 
-
-def test_cant_save_empty(make_napari_viewer, capsys):
-    viewer = make_napari_viewer()
-    widget = ParticleTracksWidget(viewer)
-
+def test_cant_save_empty(cpt_widget, capsys):
     # click the save button
-    widget._on_click_save()
+    cpt_widget._on_click_save()
 
     # check we see the error info
     captured = capsys.readouterr()
     assert "No data to be saved" in captured.out
 
 
-def test_save_single_particle(make_napari_viewer, tmp_path):
+def test_save_single_particle(cpt_widget, tmp_path):
     chdir(tmp_path)  # change to the tmp_path
 
     # start napari and the particle widget, add a single particle
-    viewer = make_napari_viewer()
-    widget = ParticleTracksWidget(viewer)
-    widget.cb.setCurrentIndex(1)  # select the Σ
-    widget._on_click_new_particle()
-    assert len(widget.data) == 1, "Expecting one particle in the table"
+    cpt_widget.cb.setCurrentIndex(1)  # select the Σ
+    cpt_widget._on_click_new_particle()
+    assert len(cpt_widget.data) == 1, "Expecting one particle in the table"
 
     # click the save button
-    widget._on_click_save()
+    cpt_widget._on_click_save()
 
     # check we have a csv file
     csv_files = glob("./*.csv")

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -2,7 +2,6 @@ from math import sqrt
 
 import numpy as np
 import pytest
-from cavendish_particle_tracks import ParticleTracksWidget
 from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
 
 
@@ -54,7 +53,7 @@ from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
     ],
 )
 def test_calculate_stereoshift_ui(
-    make_napari_viewer,
+    cpt_widget,
     test_points,
     expected_fiducial_shift,
     expected_point_shift,
@@ -68,15 +67,11 @@ def test_calculate_stereoshift_ui(
     - Calculate shift_fiducial, shift_point, stereoshift and depth.
     - The textboxes should be updated.
     """
-    viewer = make_napari_viewer()
-    viewer.add_image(np.random.random((100, 100)))
-    my_widget = ParticleTracksWidget(viewer)
-
     # need to click "new particle" to add a row to the table
-    my_widget.cb.setCurrentIndex(1)
-    my_widget._on_click_new_particle()
+    cpt_widget.cb.setCurrentIndex(1)
+    cpt_widget._on_click_new_particle()
 
-    dlg = my_widget._on_click_stereoshift()
+    dlg = cpt_widget._on_click_stereoshift()
 
     # move points to parameterised positions
     for i in range(len(test_points)):


### PR DESCRIPTION
We can have our own custom `pytest.fixture` to abstract out the common test function setup code. [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)s up the tests.