### PR TITLE
Resolved bug created created in PR #64

### DIFF
--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -229,7 +229,7 @@ class StereoshiftDialog(QDialog):
             self.b(2),
             reverse=self.cbf1.currentIndex(),
         )
-        self.spoints = self.cal_layer.data[1:]
+        self.spoints = self.cal_layer.data[2:]
 
         # Populate the table
         self.tshift_fiducial.setText(str(self.shift_fiducial))


### PR DESCRIPTION
Resolved bug created in PR #64.
Data request to layer was not updated to reflect that there are now 6 points instead of 5. self.spoints threw an error because it received 5 args instead of 4.