### PR TITLE
Specify installation instructions for macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ A Napari plugin to perform a simple particle tracking analysis for the Cavendish
 
 ## Installation
 
-Firstly, you'll need to [install napari](https://napari.org/stable/tutorials/fundamentals/installation.html).
+Firstly, you'll need to [install napari](https://napari.org/stable/tutorials/fundamentals/installation.html) following their latest instructions.
 
 Then you can install this plugin with:
 
-    pip install git+https://github.com/samcunliffe/cavendish-particle-tracks.git
+    python -m pip install git+https://github.com/palvarezc/cavendish-particle-tracks.git
+
+
+> [!NOTE]
+> On macOS we've found it easier to install napari through `conda-forge` (the napari docs give instructions for this under the **'From conda-forge using conda'** tab.)
+> The Cavendish Particle tracks plugin can still be installed via `pip`, from inside your `conda` environment.
 
 
 ## Getting started


### PR DESCRIPTION
Solves 
- #84

Noting that we always said "follow napari installation instructions" but this makes it explicit. 

Also: I deliberately don't add explicit `conda create`... steps here because that's duplicating the napari instructions which is bad (users/lab computer IT people should install napari however napari says they should).

## Questions

Not related to this PR, but 
* has anyone tried installing it on whatever you will have for lab computers?
* I understood we'd _not_ be supporting Windows, is this still the case? Because we're now [testing it in CI](https://github.com/palvarezc/cavendish-particle-tracks/blob/main/.github/workflows/test_and_deploy.yml#L45-L50).