### PR TITLE
Use context manager as recommended in deprecation warning.

### DIFF
--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -9,7 +9,7 @@ def test_decay_angles_dialog(cpt_widget, qtbot: QtBot):
     qtbot.addWidget(dialog)
 
     # show dialog and check that it closes
-    dialog.show()
-    qtbot.waitForWindowShown(dialog)
+    with qtbot.waitExposed(dialog):
+        dialog.show()
     dialog.close()
     qtbot.waitSignals([dialog.rejected], timeout=5000)


### PR DESCRIPTION
Doing as the `DeprecationWarning` very helpfully told me:
```
 tests/test_decay_angles_dialog.py::test_decay_angles_dialog
    /Users/runner/work/cavendish-particle-tracks/cavendish-particle-tracks/.tox/py311-macos/lib/python3.11/site-packages/pytestqt/qtbot.py:267: DeprecationWarning: waitForWindowShown is deprecated, as the underlying Qt method was obsoleted in Qt 5.0 and removed in Qt 6.0. Its name is imprecise and the pytest-qt wrapper does not raise qtbot.TimeoutError if the window wasn't shown. Please use the qtbot.waitExposed context manager instead.
```