### PR TITLE
Stereoshift dialog: save to table

### DIFF
--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -274,38 +274,38 @@ class StereoshiftDialog(QDialog):
             self.parent.data[selected_row].stereoshift = self.point_stereoshift
             self.parent.data[selected_row].depth_cm = self.point_depth
 
-        # Propagate to parent table
-        for i in range(2):
+            # Propagate to parent table
+            for i in range(2):
+                self.parent.table.setItem(
+                    selected_row,
+                    self.parent._get_table_column_index("sf" + str(i + 1)),
+                    QTableWidgetItem(str(self.spoints[i])),
+                )
+                self.parent.table.setItem(
+                    selected_row,
+                    self.parent._get_table_column_index("sp" + str(i + 1)),
+                    QTableWidgetItem(str(self.spoints[i + 2])),
+                )
             self.parent.table.setItem(
                 selected_row,
-                self.parent._get_table_column_index("sf" + str(i + 1)),
-                QTableWidgetItem(str(self.spoints[i])),
+                self.parent._get_table_column_index("shift_fiducial"),
+                QTableWidgetItem(str(self.shift_fiducial)),
             )
             self.parent.table.setItem(
                 selected_row,
-                self.parent._get_table_column_index("sp" + str(i + 1)),
-                QTableWidgetItem(str(self.spoints[i + 2])),
+                self.parent._get_table_column_index("shift_point"),
+                QTableWidgetItem(str(self.shift_point)),
             )
-        self.parent.table.setItem(
-            selected_row,
-            self.parent._get_table_column_index("shift_fiducial"),
-            QTableWidgetItem(str(self.shift_fiducial)),
-        )
-        self.parent.table.setItem(
-            selected_row,
-            self.parent._get_table_column_index("shift_point"),
-            QTableWidgetItem(str(self.shift_point)),
-        )
-        self.parent.table.setItem(
-            selected_row,
-            self.parent._get_table_column_index("stereoshift"),
-            QTableWidgetItem(str(self.point_stereoshift)),
-        )
-        self.parent.table.setItem(
-            selected_row,
-            self.parent._get_table_column_index("depth_cm"),
-            QTableWidgetItem(str(self.point_depth)),
-        )
+            self.parent.table.setItem(
+                selected_row,
+                self.parent._get_table_column_index("stereoshift"),
+                QTableWidgetItem(str(self.point_stereoshift)),
+            )
+            self.parent.table.setItem(
+                selected_row,
+                self.parent._get_table_column_index("depth_cm"),
+                QTableWidgetItem(str(self.point_depth)),
+            )
 
     def cancel(self) -> None:
         """On cancel remove the points_Stereoshift layer"""

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -106,3 +106,18 @@ def test_calculate_stereoshift_ui(
     assert cpt_widget.data[0].stereoshift == dlg.point_stereoshift
     # these names should be more consistent between different parts of the program
     assert cpt_widget.data[0].depth_cm == dlg.point_depth
+
+
+def test_stereoshift_save_to_table_fails_with_empty_table(cpt_widget, capsys):
+    """Test the expected failure modes: if I don't have any data in the table."""
+    # open the dialog
+    dlg = cpt_widget._on_click_stereoshift()
+
+    # click the save to table button
+    dlg._on_click_save_to_table()
+    captured = capsys.readouterr()
+
+    assert (
+        "ERROR: There are no particles in the table."
+        in captured.out
+    )

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -117,7 +117,4 @@ def test_stereoshift_save_to_table_fails_with_empty_table(cpt_widget, capsys):
     dlg._on_click_save_to_table()
     captured = capsys.readouterr()
 
-    assert (
-        "ERROR: There are no particles in the table."
-        in captured.out
-    )
+    assert "ERROR: There are no particles in the table." in captured.out


### PR DESCRIPTION
Bug fix for `Save to table` action in the `StereoshiftDialog`, when no particles have been added to the table.
Will become redundant when enable/disable buttons is implemented.