### PR TITLE
Remove API docs from the website, add a GitHub logo link, and update some outdated things.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Presumably also with the testing dependencies:
     python -m pip install -e ".[testing]"
 
 
-Tests are run with [tox] across python 3.9, 3.10 and 3.11.
+Tests are run with [tox] across python 3.9, 3.10, 3.11 and 3.12.
 You can also check quickly with `pytest` if you installed the `testing` extras.
 Please ensure the coverage at least stays the same before you submit a pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,6 @@ We also use `pre-commit` to ensure uniform code style.
     python -m pip install pre-commit
     pre-commit run # before committing
 
-Open PRs without a reviewer can be treated as a draft. When a reviewer is added this counts as ready for review.
-(When open source we'll use proper drafts.)
-
-
 [tox]: https://tox.readthedocs.io/en/latest/
 
 ## Contributing documentation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><img src="./docs/ParticleCrocodile.png" width=300 /></p>
 
 [![License MIT](https://img.shields.io/badge/license-MIT-blue)](https://github.com/samcunliffe/cavendish-particle-tracks/raw/main/LICENSE)
-[![Python Version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)](https://python.org)
+[![Python Version](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12-blue)](https://python.org)
 [![ci](https://github.com/palvarezc/cavendish-particle-tracks/workflows/ci/badge.svg)](https://github.com/palvarezc/cavendish-particle-tracks/actions)
 [![codecov](https://codecov.io/github/palvarezc/cavendish-particle-tracks/graph/badge.svg?token=9R8IVMJT90)](https://codecov.io/github/palvarezc/cavendish-particle-tracks)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v0.json)](https://github.com/charliermarsh/ruff)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,0 @@
-
-API
-===
-
-.. automodule:: cavendish_particle_tracks
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,6 @@
 
    user-manual
    contributing
-   api
 
 .. include:: ../README.md
    :parser: myst_parser.sphinx_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 requires-python = ">=3.9"
@@ -143,12 +143,11 @@ exclude = [
 legacy_tox_ini = """
 
 [tox]
-envlist = py{38,39,310,311}-{linux,macos,windows}
+envlist = py{39,310,311,312}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ file = "README.md"
 content-type = "text/markdown"
 
 [project.urls]
-Homepage = "https://github.com/samcunliffe/cavendish-particle-tracks"
+Homepage = "https://palvarezc.github.io/cavendish-particle-tracks/"
 "Bug Tracker" = "https://github.com/samcunliffe/cavendish-particle-tracks/issues"
-Documentation = "https://github.com/samcunliffe/cavendish-particle-tracks#readme"
+Documentation = "https://palvarezc.github.io/cavendish-particle-tracks/user-manual.html"
 "Source Code" = "https://github.com/samcunliffe/cavendish-particle-tracks"
 "User Support" = "https://github.com/samcunliffe/cavendish-particle-tracks/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,10 @@ extensions = [
     'myst_parser',
 ]
 
+html_theme_options = { icon_links = [
+    { name = "GitHub", url = "https://github.com/samcunliffe/cavendish-particle-tracks", icon = "fa-brands fa-github" },
+] }
+
 # remove the primary sidebar on all pages
 # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#primary-sidebar-left
 html_sidebars = { "**" = [] }


### PR DESCRIPTION
#### Remove the API docs from the website
As most of the code is private ... `_private_module.py` or `Widget._private_member` it isn't documented by default anyway. And it's not really for the users to read. Can always revisit if it's useful later.

#### Others
- GitHub link to the code.
- Update some project URLs.
- Found a few mentions of Python 3.8.
