### PR TITLE
Avoid tool duplication

### DIFF
--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -43,7 +43,7 @@ class DecayAnglesDialog(QDialog):
         bap.clicked.connect(self._on_click_save_to_table)
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Cancel)
-        self.buttonBox.clicked.connect(self.cancel)
+        self.buttonBox.clicked.connect(self.reject)
 
         # layout
         self.setLayout(QGridLayout())
@@ -191,11 +191,11 @@ class DecayAnglesDialog(QDialog):
                 QTableWidgetItem(str(self.phi_pion)),
             )
 
-    def cancel(self) -> None:
+    def reject(self) -> None:
         """On cancel remove the points_Stereoshift layer"""
 
         # TODO: this is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()
         self.parent.viewer.layers.remove(self.cal_layer)
         self.parent.decay_angles_is_open = False
-        return super().accept()
+        return super().reject()

--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -84,9 +84,8 @@ class DecayAnglesDialog(QDialog):
 
     def _setup_decayangles_layer(self):
         """Create a shapes layer and add three lines to measure the Lambda, p and pi tracks"""
-        for layer in self.parent.viewer.layers:
-            if layer.name == "Decay Angles Tool":
-                return layer
+        if "Decay Angles Tool" in self.parent.viewer.layers:
+            return self.parent.viewer.layers["Decay Angles Tool"]
         origin_x = self.parent.camera_center[0]
         # note down why this is preferred....
         origin_y = self.parent.camera_center[1]

--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -84,7 +84,9 @@ class DecayAnglesDialog(QDialog):
 
     def _setup_decayangles_layer(self):
         """Create a shapes layer and add three lines to measure the Lambda, p and pi tracks"""
-
+        for layer in self.parent.viewer.layers:
+            if layer.name == "Decay Angles Tool":
+                return layer
         origin_x = self.parent.camera_center[0]
         # note down why this is preferred....
         origin_y = self.parent.camera_center[1]

--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -197,4 +197,5 @@ class DecayAnglesDialog(QDialog):
         # TODO: this is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()
         self.parent.viewer.layers.remove(self.cal_layer)
+        self.parent.decay_angles_is_open = False
         return super().accept()

--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -84,6 +84,8 @@ class DecayAnglesDialog(QDialog):
 
     def _setup_decayangles_layer(self):
         """Create a shapes layer and add three lines to measure the Lambda, p and pi tracks"""
+
+        # If layer already exists, then assume it was set up previously.
         if "Decay Angles Tool" in self.parent.viewer.layers:
             return self.parent.viewer.layers["Decay Angles Tool"]
         origin_x = self.parent.camera_center[0]

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -194,5 +194,5 @@ class MagnificationDialog(QDialog):
     def reject(self) -> None:
         """On reject remove the magnification layer"""
 
-        self._deactivate_cal_layer()
+        self._deactivate_calibration_layer()
         return super().reject()

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -185,7 +185,7 @@ class MagnificationDialog(QDialog):
 
         print("Propagating magnification to table.")
         self.parent._propagate_magnification(self.a, self.b)
-        self._deactivate_cal_layer()
+        self._deactivate_calibration_layer()
         self.parent.cal.setEnabled(True)
         # self.parent.mag.setEnabled(False)
         self.parent.mag.setText("Update magnification")

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -93,10 +93,13 @@ class MagnificationDialog(QDialog):
 
         self.layout().addWidget(self.buttonBox, 9, 0, 1, 3)
 
-        self.cal_layer = self.parent.viewer.add_points(
-            name="Points_Calibration"
-        )
+        def create_retrieve_magnification_layer(self):
+            for layer in self.parent.viewer.layers:
+                if layer.name == "Magnification":
+                    return layer
+            self.parent.viewer.add_points(name="Magnification")
 
+        self.cal_layer = create_retrieve_magnification_layer(self)
         self.a = parent.mag_a
         self.b = parent.mag_b
 

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -171,7 +171,7 @@ class MagnificationDialog(QDialog):
         )
         self.parent.viewer.layers.selection.active = self.cal_layer
 
-    def _deactivate_cal_layer(self):
+    def _deactivate_calibration_layer(self):
         """Hide the calibration layer and move it to the bottom"""
         # self.parent.viewer.layers.select_previous()
         self.cal_layer.visible = False

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -135,9 +135,7 @@ class MagnificationDialog(QDialog):
     def _add_coords(self, fiducial: int) -> list[float]:
         """When 'Add' is selected, the selected point is added to the corresponding fiducial text box"""
 
-        selected_points = self.parent._get_selected_points(
-            "Points_Calibration"
-        )
+        selected_points = self.parent._get_selected_points("Magnification")
 
         # Forcing only 1 points
         if len(selected_points) != 1:
@@ -178,7 +176,7 @@ class MagnificationDialog(QDialog):
         return super().accept()
 
     def reject(self) -> None:
-        """On reject remove the points_Calibration layer"""
+        """On reject remove the magnification layer"""
 
         # This is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -93,12 +93,12 @@ class MagnificationDialog(QDialog):
 
         self.layout().addWidget(self.buttonBox, 9, 0, 1, 3)
 
-        def create_retrieve_magnification_layer(self):
+        def create_or_retrieve_magnification_layer(self):
             if "Magnification" in self.parent.viewer.layers:
                 return self.parent.viewer.layers["Magnification"]
             return self.parent.viewer.add_points(name="Magnification")
 
-        self.cal_layer = create_retrieve_magnification_layer(self)
+        self.cal_layer = create_or_retrieve_magnification_layer(self)
         self.a = parent.mag_a
         self.b = parent.mag_b
 

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -161,7 +161,7 @@ class MagnificationDialog(QDialog):
         self.table.setItem(0, 0, QTableWidgetItem(str(self.a)))
         self.table.setItem(0, 1, QTableWidgetItem(str(self.b)))
 
-    def _activate_cal_layer(self):
+    def _activate_calibration_layer(self):
         """Show the calibration layer and move it to the top"""
         self.cal_layer.visible = True
         # Move the calibration layer to the top

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -313,4 +313,5 @@ class StereoshiftDialog(QDialog):
         # TODO: this is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()
         self.parent.viewer.layers.remove(self.cal_layer)
+        self.parent.stereoshift_isopen = False
         return super().accept()

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -68,7 +68,7 @@ class StereoshiftDialog(QDialog):
         bap.clicked.connect(self._on_click_save_to_table)
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Cancel)
-        self.buttonBox.clicked.connect(self.cancel)
+        self.buttonBox.clicked.connect(self.reject)
 
         lviewf1 = QLabel("View 1")
         lviewf2 = QLabel("View 2")
@@ -307,11 +307,11 @@ class StereoshiftDialog(QDialog):
                 QTableWidgetItem(str(self.point_depth)),
             )
 
-    def cancel(self) -> None:
+    def reject(self) -> None:
         """On cancel remove the points_Stereoshift layer"""
 
         # TODO: this is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()
         self.parent.viewer.layers.remove(self.cal_layer)
         self.parent.stereoshift_isopen = False
-        return super().accept()
+        return super().reject()

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -111,6 +111,8 @@ class ParticleTracksWidget(QWidget):
         # might not need this eventually
         self.mag_a = -1.0e6
         self.mag_b = -1.0e6
+        # Magnification dialog
+        self.mag_dlg: MagnificationDialog | None = None
 
     @property
     def camera_center(self):
@@ -337,7 +339,7 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
-        #for widget in QApplication.topLevelWidgets():
+        # for widget in QApplication.topLevelWidgets():
         ##    if isinstance(widget, DecayAnglesDialog):
         ##        napari.utils.notifications.show_error(
         ##            "Decay Angles dialog already open"
@@ -503,17 +505,15 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_magnification(self) -> MagnificationDialog:
         """When the 'Calculate magnification' button is clicked, open the magnification dialog"""
-        for widget in QApplication.topLevelWidgets():
-            if isinstance(widget, MagnificationDialog):
-                napari.utils.notifications.show_error(
-                    "Magnification dialog already open"
-                )
-                return widget
-        dlg = MagnificationDialog(self)
-        dlg.show()
+        if self.mag_dlg is not None:
+            self.mag_dlg.show()
+            self.mag_dlg._activate_cal_layer()
+            return self.mag_dlg
+        self.mag_dlg = MagnificationDialog(self)
+        self.mag_dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
-        dlg.move(point)
-        return dlg
+        self.mag_dlg.move(point)
+        return self.mag_dlg
 
     def _propagate_magnification(self, a: float, b: float) -> None:
         """Assigns a and b to the class magnification parameters and to each of the particles in data"""

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -115,6 +115,8 @@ class ParticleTracksWidget(QWidget):
         self.mag_dlg: MagnificationDialog | None = None
         self.stereoshift_dlg: StereoshiftDialog | None = None
         self.stereoshift_isopen = False
+        self.decay_angles_dlg: DecayAnglesDialog | None = None
+        self.decay_angles_isopen = False
 
     @property
     def camera_center(self):
@@ -341,17 +343,17 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
-        # for widget in QApplication.topLevelWidgets():
-        ##    if isinstance(widget, DecayAnglesDialog):
-        ##        napari.utils.notifications.show_error(
-        ##            "Decay Angles dialog already open"
-        ##        )
-        #        return widget
-        dlg = DecayAnglesDialog(self)
-        dlg.show()
+        if (self.decay_angles_dlg is not None) and (
+            self.decay_angles_isopen is True
+        ):
+            self.decay_angles_dlg.raise_()
+            return self.decay_angles_dlg
+        self.decay_angles_dlg = DecayAnglesDialog(self)
+        self.decay_angles_dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
-        dlg.move(point)
-        return dlg
+        self.decay_angles_dlg.move(point)
+        self.decay_angles_isopen = True
+        return self.decay_angles_dlg
 
     def _on_click_stereoshift(self) -> StereoshiftDialog:
         """When the 'Calculate stereoshift' button is clicked, open stereoshift dialog."""

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -513,7 +513,7 @@ class ParticleTracksWidget(QWidget):
         if self.mag_dlg is not None:
             self.mag_dlg.show()
             self.mag_dlg.raise_()
-            self.mag_dlg._activate_cal_layer()
+            self.mag_dlg._activate_calibration_layer()
             return self.mag_dlg
         self.mag_dlg = MagnificationDialog(self)
         self.mag_dlg.show()

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -337,12 +337,12 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
-        for widget in QApplication.topLevelWidgets():
-            if isinstance(widget, DecayAnglesDialog):
-                napari.utils.notifications.show_error(
-                    "Decay Angles dialog already open"
-                )
-                return widget
+        #for widget in QApplication.topLevelWidgets():
+        ##    if isinstance(widget, DecayAnglesDialog):
+        ##        napari.utils.notifications.show_error(
+        ##            "Decay Angles dialog already open"
+        ##        )
+        #        return widget
         dlg = DecayAnglesDialog(self)
         dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -511,6 +511,7 @@ class ParticleTracksWidget(QWidget):
     def _on_click_magnification(self) -> MagnificationDialog:
         """When the 'Calculate magnification' button is clicked, open the magnification dialog"""
         if self.mag_dlg is not None:
+            self.mag_dlg.show()
             self.mag_dlg.raise_()
             self.mag_dlg._activate_cal_layer()
             return self.mag_dlg

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -16,6 +16,7 @@ from dask_image.imread import imread
 from qtpy.QtCore import QPoint
 from qtpy.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QComboBox,
     QFileDialog,
     QMessageBox,
@@ -334,15 +335,28 @@ class ParticleTracksWidget(QWidget):
             print("Modified particle ", selected_row)
             print(self.data[selected_row])
 
-    def _on_click_decay_angles(self) -> None:
+    def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, DecayAnglesDialog):
+                napari.utils.notifications.show_error(
+                    "Decay Angles dialog already open"
+                )
+                return widget
         dlg = DecayAnglesDialog(self)
         dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
         dlg.move(point)
+        return dlg
 
     def _on_click_stereoshift(self) -> StereoshiftDialog:
         """When the 'Calculate stereoshift' button is clicked, open stereoshift dialog."""
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, StereoshiftDialog):
+                napari.utils.notifications.show_error(
+                    "Stereoshift dialog already open"
+                )
+                return widget
         dlg = StereoshiftDialog(self)
         dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
@@ -467,9 +481,6 @@ class ParticleTracksWidget(QWidget):
         print(self.data[-1])
         self.cb.setCurrentIndex(0)
 
-        # # napari notifications
-        # napari.utils.notifications.show_info("I created a new particle")
-
     def _on_click_delete_particle(self) -> None:
         """Delete particle from table and data"""
         try:
@@ -492,7 +503,12 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_magnification(self) -> MagnificationDialog:
         """When the 'Calculate magnification' button is clicked, open the magnification dialog"""
-
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, MagnificationDialog):
+                napari.utils.notifications.show_error(
+                    "Magnification dialog already open"
+                )
+                return widget
         dlg = MagnificationDialog(self)
         dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -9,7 +9,7 @@ from pytestqt.qtbot import QtBot
         False,
     ],
 )
-def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, double_click):
+def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, click_twice: bool):
     """Smoke test for the DecayAnglesDialog."""
     cpt_widget.cb.setCurrentIndex(4)
 

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -1,11 +1,22 @@
+import pytest
 from pytestqt.qtbot import QtBot
 
-from cavendish_particle_tracks._decay_angles_dialog import DecayAnglesDialog
 
-
-def test_decay_angles_dialog(cpt_widget, qtbot: QtBot):
+@pytest.mark.parametrize(
+    "double_click",
+    [
+        True,
+        False,
+    ],
+)
+def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, double_click):
     """Smoke test for the DecayAnglesDialog."""
-    dialog = DecayAnglesDialog(parent=cpt_widget)
+    cpt_widget.cb.setCurrentIndex(4)
+
+    dialog = cpt_widget._on_click_decay_angles()
+    if double_click:
+        dialog = cpt_widget._on_click_decay_angles()
+
     qtbot.addWidget(dialog)
 
     # show dialog and check that it closes

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -3,7 +3,7 @@ from pytestqt.qtbot import QtBot
 
 
 @pytest.mark.parametrize(
-    "double_click",
+    "click_twice",
     [
         True,
         False,

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -13,9 +13,10 @@ def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, click_twice: bool):
     """Smoke test for the DecayAnglesDialog."""
     cpt_widget.cb.setCurrentIndex(4)
 
+    # The user clicks the button (also test fringe case that they click the button again).
+    if click_twice:
+        cpt_widget._on_click_decay_angles()
     dialog = cpt_widget._on_click_decay_angles()
-    if double_click:
-        dialog = cpt_widget._on_click_decay_angles()
 
     qtbot.addWidget(dialog)
 

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -7,8 +7,9 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_BACK as FB
 from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
 
 
+@pytest.mark.parametrize("click_twice", [True, False])
 @pytest.mark.parametrize(
-    "front_fiducial1, front_fiducial2, back_fiducial1, back_fiducial2, expected_magnification_params, double_click",
+    "front_fiducial1, front_fiducial2, back_fiducial1, back_fiducial2, expected_magnification_params",
     [
         (
             Fiducial("C'", *FF["C'"]),
@@ -16,7 +17,6 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *FB["C"]),
             Fiducial("F", *FB["F"]),
             (1.0, 0.0),
-            True,
         ),
         (
             Fiducial("C'", *np.multiply(2, FF["C'"])),
@@ -24,7 +24,6 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *np.multiply(2, FB["C"])),
             Fiducial("F", *np.multiply(2, FB["F"])),
             (0.5, 0.0),
-            False,
         ),
         (
             Fiducial("C'", *np.multiply(2, FF["C'"])),
@@ -32,7 +31,6 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *np.divide(FB["C"], 0.5 + 0.3 * CD)),
             Fiducial("F", *np.divide(FB["F"], 0.5 + 0.3 * CD)),
             (0.5, 0.3),
-            False,
         ),
     ],
 )

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -49,9 +49,10 @@ def test_magnification_ui(
     - Magnification is calculated on click of calculate button.
     - Magnification is propagated to the table when "ok" is clicked.
     """
+    # The user opens the child dialog (also test fringe case that they click the button again).
+    if click_twice:
+        cpt_widget._on_click_magnification()
     dlg = cpt_widget._on_click_magnification()
-    if double_click:
-        dlg = cpt_widget._on_click_magnification()
 
     # add fiducials
     fiducials = [

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -78,6 +78,7 @@ def test_magnification_ui(
         dlg.cal_layer.selected_data = {len(dlg.cal_layer.data) - 1}
         add_fiducial_func()
         assert recorded_fiducial == fiducial
+        # TODO: check text box
 
     dlg._on_click_magnification()
     assert dlg.a == pytest.approx(expected_magnification_params[0], rel=1e-3)

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -41,7 +41,7 @@ def test_magnification_ui(
     back_fiducial1,
     back_fiducial2,
     expected_magnification_params,
-    double_click,
+    click_twice,
 ):
     """Tests the expected behaviour from the expected workflow.
     - Add 4 fiducials in layer

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -8,7 +8,7 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
 
 
 @pytest.mark.parametrize(
-    "front_fiducial1, front_fiducial2, back_fiducial1, back_fiducial2, expected_magnification_params",
+    "front_fiducial1, front_fiducial2, back_fiducial1, back_fiducial2, expected_magnification_params, double_click",
     [
         (
             Fiducial("C'", *FF["C'"]),
@@ -16,6 +16,7 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *FB["C"]),
             Fiducial("F", *FB["F"]),
             (1.0, 0.0),
+            True,
         ),
         (
             Fiducial("C'", *np.multiply(2, FF["C'"])),
@@ -23,6 +24,7 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *np.multiply(2, FB["C"])),
             Fiducial("F", *np.multiply(2, FB["F"])),
             (0.5, 0.0),
+            False,
         ),
         (
             Fiducial("C'", *np.multiply(2, FF["C'"])),
@@ -30,6 +32,7 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
             Fiducial("C", *np.divide(FB["C"], 0.5 + 0.3 * CD)),
             Fiducial("F", *np.divide(FB["F"], 0.5 + 0.3 * CD)),
             (0.5, 0.3),
+            False,
         ),
     ],
 )
@@ -40,6 +43,7 @@ def test_magnification_ui(
     back_fiducial1,
     back_fiducial2,
     expected_magnification_params,
+    double_click,
 ):
     """Tests the expected behaviour from the expected workflow.
     - Add 4 fiducials in layer
@@ -48,6 +52,8 @@ def test_magnification_ui(
     - Magnification is propagated to the table when "ok" is clicked.
     """
     dlg = cpt_widget._on_click_magnification()
+    if double_click:
+        dlg = cpt_widget._on_click_magnification()
 
     # add fiducials
     fiducials = [

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -11,7 +11,7 @@ from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
 
 
 @pytest.mark.parametrize(
-    "test_points, expected_fiducial_shift, expected_point_shift, expected_stereoshift, expected_depth",
+    "test_points, expected_fiducial_shift, expected_point_shift, expected_stereoshift, expected_depth, double_click",
     [
         (
             [
@@ -26,6 +26,7 @@ from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
             sqrt(2),
             0.5,
             0.5 * CHAMBER_DEPTH,
+            True,
         ),
         (
             [
@@ -40,6 +41,7 @@ from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
             1.0,
             1 / sqrt(8),
             1 / sqrt(8) * CHAMBER_DEPTH,
+            False,
         ),
         (
             [
@@ -54,6 +56,7 @@ from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
             sqrt(0),
             0.0,
             0.0 * CHAMBER_DEPTH,
+            False,
         ),
     ],
 )
@@ -64,6 +67,7 @@ def test_calculate_stereoshift_ui(
     expected_point_shift,
     expected_stereoshift,
     expected_depth,
+    double_click,
 ):
     """Test the expected behavior from the expected workflow:
 
@@ -76,6 +80,8 @@ def test_calculate_stereoshift_ui(
     cpt_widget.cb.setCurrentIndex(1)
 
     dlg = cpt_widget._on_click_stereoshift()
+    if double_click:
+        dlg = cpt_widget._on_click_stereoshift()
 
     # move points to parameterised positions
     for i in range(len(test_points)):

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -90,8 +90,6 @@ def test_calculate_stereoshift_ui(
             test_points[i + 2] - test_points[i % 2]
         )
 
-    assert dlg.cbf1.currentIndex() == 0
-
     # Check calculated values
     assert dlg.tshift_fiducial.text() == str(expected_fiducial_shift)
     assert dlg.tshift_point.text() == str(expected_point_shift)


### PR DESCRIPTION
Trying to separate out the different elements from:
- #104 

In this PR: 
- Avoid layer duplication when repeatedly hitting the same Magnification, Stereoshift or Decay angles button
- Tried to `cherry-pick` from @Joseph-Garvey commits
- Changed the implementation with `QApplication` to use some flags instead, as the tests open several `QApplication` instances and finding a widget from all applications was not safe.