### PR TITLE
Load button disable + hide layer controls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "imagecodecs",    # for opening tiff images on macos
-    "napari > 0.5.2", # need to be able to open as stack (https://github.com/napari/napari/issues/7165)
+    "napari >= 0.5.2, < 0.6.0", # need >= 0.5.2 to be able to open as stack (https://github.com/napari/napari/issues/7165) and < 0.6.0 to hide layers controls
     "numpy",
     "dask-image",     # for image loading
 ]

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -88,7 +88,6 @@ class ParticleTracksWidget(QWidget):
         # self.viewer.events.mouse_press(self._on_mouse_click)
 
         # layout
-        self.viewer.window._qt_viewer.layerButtons.hide()  # This will break in napari 0.6.0
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.load)
         self.layout().addWidget(self.cb)
@@ -101,6 +100,10 @@ class ParticleTracksWidget(QWidget):
         self.layout().addWidget(self.stsh)
         self.layout().addWidget(self.mag)
         self.layout().addWidget(save)
+
+        # Disable native napari layer controls - show again on closing this widget (hide).
+        # NB: This will break in napari 0.6.0
+        self.viewer.window._qt_viewer.layerButtons.hide()
 
         # disable all calculation buttons
         self.disable_all_buttons()
@@ -118,6 +121,11 @@ class ParticleTracksWidget(QWidget):
         self.stereoshift_isopen = False
         self.decay_angles_dlg: DecayAnglesDialog | None = None
         self.decay_angles_isopen = False
+
+    def hideEvent(self, event):
+        """When the widget is 'closed' (napari just hides it), show the layer buttons again."""
+        self.viewer.window._qt_viewer.layerButtons.show()
+        super().hideEvent(event)
 
     @property
     def camera_center(self):

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -88,6 +88,7 @@ class ParticleTracksWidget(QWidget):
         # self.viewer.events.mouse_press(self._on_mouse_click)
 
         # layout
+        self.viewer.window._qt_viewer.layerButtons.hide()  # This will break in napari 0.6.0
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.load)
         self.layout().addWidget(self.cb)
@@ -450,6 +451,9 @@ class ParticleTracksWidget(QWidget):
                 border_width=7,
                 border_width_is_relative=False,
             )
+
+        # Disable the load button after loading the data (interim solution until we can move to bottom-docked UI)
+        self.load.setEnabled(False)
 
     def _on_click_new_particle(self) -> None:
         """When the 'New particle' button is clicked, append a new blank row to


### PR DESCRIPTION
Provisional hack while we figure out how to dock at the bottom by default:
- Load button disabled when the data has been loaded
- Layer controls hiden from the user