### PR TITLE
Offer save data dialog on widget closure

### DIFF
--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -127,7 +127,8 @@ class ParticleTracksWidget(QWidget):
         If data has been recorded, prompt the user to save it before closing the widget.
         """
         if len(self.data) > 0:
-            message_box = QMessageBox()
+            message_box = QMessageBox(self)
+            message_box.setIcon(QMessageBox.Warning)
             message_box.setText(
                 "Closing Cavendish Particle Tracks. Any unsaved data will be lost."
             )

--- a/src/cavendish_particle_tracks/_widget.py
+++ b/src/cavendish_particle_tracks/_widget.py
@@ -123,7 +123,21 @@ class ParticleTracksWidget(QWidget):
         self.decay_angles_isopen = False
 
     def hideEvent(self, event):
-        """When the widget is 'closed' (napari just hides it), show the layer buttons again."""
+        """When the widget is 'closed' (napari just hides it), show the layer buttons again.
+        If data has been recorded, prompt the user to save it before closing the widget.
+        """
+        if len(self.data) > 0:
+            message_box = QMessageBox()
+            message_box.setText(
+                "Closing Cavendish Particle Tracks. Any unsaved data will be lost."
+            )
+            message_box.setInformativeText("Do you want to save your data?")
+            message_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+            message_box.setDefaultButton(QMessageBox.Yes)
+            reply = message_box.exec()
+
+            if reply == QMessageBox.Yes:
+                self._on_click_save()
         self.viewer.window._qt_viewer.layerButtons.show()
         super().hideEvent(event)
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -254,3 +254,25 @@ def test_show_hide_buttons(cpt_widget: ParticleTracksWidget):
     assert cpt_widget.rad.isEnabled() is False
     assert cpt_widget.lgth.isEnabled() is True
     assert cpt_widget.ang.isEnabled() is True
+
+
+def test_close_widget(cpt_widget: ParticleTracksWidget, qtbot: QtBot):
+    """Test the close button"""
+    cpt_widget.cb.setCurrentIndex(4)
+    cpt_widget.show()  # the function hideEvent is not called if the widget is not shown
+
+    def check_dialog_and_click_no(dialog):
+        assert isinstance(dialog, QMessageBox)
+        assert dialog.icon() == QMessageBox.Warning
+        assert dialog.text() == (
+            "Closing Cavendish Particle Tracks. Any unsaved data will be lost."
+        )
+        buttonbox = dialog.findChild(QDialogButtonBox)
+        nobutton = buttonbox.children()[2]
+        nobutton.click()
+
+    get_dialog(
+        dialog_trigger=cpt_widget.window().close,
+        dialog_action=check_dialog_and_click_no,
+        time_out=5,
+    )


### PR DESCRIPTION
On click of the close button for the widget or the main window, open a message box offering the option to save the data.