### PR TITLE
Prevent crash due to view rotation.

### DIFF
--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -129,6 +129,7 @@ class ParticleTracksWidget(QWidget):
         if len(self.data) > 0:
             self._confirm_save_before_closing()
         self.viewer.window._qt_viewer.layerButtons.show()
+        self.viewer.window._qt_viewer.viewerButtons.show()
         super().hideEvent(event)
 
     def _confirm_save_before_closing(self):

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -38,9 +38,9 @@ class ParticleTracksWidget(QWidget):
 
     layer_measurements: napari.layers.Points
 
-    def __init__(self, napari_viewer: napari.viewer.Viewer):
+    def __init__(self, napari_viewer: napari.Viewer):
         super().__init__()
-        self.viewer: napari.viewer.Viewer = napari_viewer
+        self.viewer: napari.Viewer = napari_viewer
         # define QtWidgets
         self.load_button = QPushButton("Load data")
         self.particle_decays_menu = QComboBox()

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -101,9 +101,10 @@ class ParticleTracksWidget(QWidget):
         self.layout().addWidget(save_data_button)
 
         # Disable native napari layer controls - show again on closing this widget (hide).
-        # NB: This will break in napari 0.6.0
+        # NB: Both of these will break in napari 0.6.0
         self.viewer.window._qt_viewer.layerButtons.hide()
-
+        # Disable viewer buttons, prevents accidental crash due to viewing image stack side on.
+        self.viewer.window._qt_viewer.viewerButtons.hide()
         # disable all calculation buttons
         self.disable_all_buttons()
         # TODO: include self.stsh in the logic, depending on what it actually ends up doing


### PR DESCRIPTION
From #141 (user testing)
> Advise students to not click the "Change the order of visible axes" icon, it made my computer struggle a bit.

What's better than telling someone not to press the big red button?
remove the big red button.

The user doesn't need to use the other buttons in this toolbar anyways, so no harm in removing it.
This doesn't change the dependency on Napari <0.6.0, as this is required by the deletion of the layer menu anyways.