### PR TITLE
After magnification dialog is closed, return focus to measurements layer

### DIFF
--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -215,7 +215,7 @@ class MagnificationDialog(QDialog):
 
     def _deactivate_calibration_layer(self):
         """Hide the calibration layer and move it to the bottom"""
-        # self.parent.viewer.layers.select_previous()
+        self.parent.viewer.layers.select_previous()
         self.magnification_layer.visible = False
         # Move the calibration layer to the bottom
         self.parent.viewer.layers.move(


### PR DESCRIPTION
Addressing user feedback:
- #141 

regarding the extra click needed to select the "Radii and Lengths" layer after the magnification dialog is closed.