### PR TITLE
Fix error with re-launching decay angles dialog

### DIFF
--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -195,5 +195,5 @@ class DecayAnglesDialog(QDialog):
         # TODO: this is a problem, the layer still exists... not sure how to remove it
         self.parent.viewer.layers.select_previous()
         self.parent.viewer.layers.remove(self.cal_layer)
-        self.parent.decay_angles_is_open = False
+        self.parent.decay_angles_isopen = False
         return super().reject()


### PR DESCRIPTION
Addressing user feedback:
- #141 

regarding the bug with the decay angles dialog, which will not reopen after it has been opened and closed once.
