### PR TITLE
Reshuffle the data and show first event

### DIFF
--- a/src/cavendish_particle_tracks/_analysis.py
+++ b/src/cavendish_particle_tracks/_analysis.py
@@ -72,9 +72,10 @@ class ParticleDecay:
     magnification_a: float = -1.0
     magnification_b: float = 0.0
     # magnification: float = -1.0
-    event_number: int = -1
     phi_proton: float = -100
     phi_pion: float = -100
+    event_number: int = -1
+    view_number: int = -1
 
     def _vars_to_show(self, calibrated=False):
         if calibrated:

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -538,6 +538,7 @@ class ParticleTracksWidget(QWidget):
         )
         # Checks that each subdirectory contains the same number of images.
         image_count_first = len(glob.glob(folder_subdirs[0] + "/*"))
+        more_than_one_image = image_count_first > 1
         same_image_count = all(
             len(glob.glob(subdir + "/*")) == image_count_first
             for subdir in folder_subdirs
@@ -548,13 +549,14 @@ class ParticleTracksWidget(QWidget):
             three_subdirectories
             and subdir_names_contain_views
             and same_image_count
+            and more_than_one_image
         ):
             self.msg = QMessageBox()
             self.msg.setIcon(QMessageBox.Warning)
             self.msg.setWindowTitle("Data folder structure error")
             self.msg.setStandardButtons(QMessageBox.Ok)
             self.msg.setText(
-                "The data folder must contain three subfolders, one for each view, and each subfolder must contain the same number of images."
+                "The data folder must contain three subfolders, one for each view, and each subfolder must contain the same number (>1) of images."
             )
             self.msg.show()
             return

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -198,7 +198,7 @@ def test_calculate_length_fails_with_wrong_number_of_points(
 @pytest.mark.parametrize(
     "data_subdirs, image_count, expect_data_loaded, reload",
     [
-        (["my_view1", "my_view2", "my_view3"], [2, 2, 2], True, False),
+        (["my_view1", "my_view2", "my_view3"], [5, 5, 5], True, False),
         (["my_view1", "my_view2", "my_view3"], [2, 2, 2], True, True),
         (["my_view1", "my_view2"], [2, 2], False, False),
         (["my_view1", "my_view2", "my_view3"], [1, 2, 2], False, False),
@@ -254,6 +254,7 @@ def test_load_data(
             == "Particle Tracks"
         )
         assert cpt_widget.viewer.layers[data_layer_index].ndim == 4
+        assert cpt_widget.viewer.dims.current_step[1] == 0
     else:
         # def capture_msgbox():
         #    for widget in QApplication.topLevelWidgets():

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -269,7 +269,7 @@ def test_load_data(
         assert isinstance(msgbox, QMessageBox)
         assert msgbox.icon() == QMessageBox.Warning
         assert msgbox.text() == (
-            "The data folder must contain three subfolders, one for each view, and each subfolder must contain the same number of images."
+            "The data folder must contain three subfolders, one for each view, and each subfolder must contain the same number (>1) of images."
         )
 
 


### PR DESCRIPTION
The `Event` dimension of the data randomly reshuffled according to the new parameter `reshuffling_seed`. The idea is to set this seed differently for different machines.

Also, `napari` shows the centre of the stack by default. Changed behaviour to show first event on loading the data.

Added a check of the number of images per view, to avoid:
- #156 