### PR TITLE
Make all tools reusable

### DIFF
--- a/src/cavendish_particle_tracks/_decay_angles_dialog.py
+++ b/src/cavendish_particle_tracks/_decay_angles_dialog.py
@@ -191,9 +191,5 @@ class DecayAnglesDialog(QDialog):
 
     def reject(self) -> None:
         """On cancel remove the points_Stereoshift layer"""
-
-        # TODO: this is a problem, the layer still exists... not sure how to remove it
-        self.parent.viewer.layers.select_previous()
-        self.parent.viewer.layers.remove(self.cal_layer)
-        self.parent.decay_angles_isopen = False
+        self.parent._deactivate_calibration_layer(self.cal_layer)
         return super().reject()

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -203,31 +203,12 @@ class MagnificationDialog(QDialog):
         self.table.setItem(0, 0, QTableWidgetItem(str(self.a)))
         self.table.setItem(0, 1, QTableWidgetItem(str(self.b)))
 
-    def _activate_calibration_layer(self):
-        """Show the calibration layer and move it to the top"""
-        self.magnification_layer.visible = True
-        # Move the calibration layer to the top
-        self.parent.viewer.layers.move(
-            self.parent.viewer.layers.index(self.magnification_layer),
-            len(self.parent.viewer.layers),
-        )
-        self.parent.viewer.layers.selection.active = self.magnification_layer
-
-    def _deactivate_calibration_layer(self):
-        """Hide the calibration layer and move it to the bottom"""
-        self.parent.viewer.layers.select_previous()
-        self.magnification_layer.visible = False
-        # Move the calibration layer to the bottom
-        self.parent.viewer.layers.move(
-            self.parent.viewer.layers.index(self.magnification_layer), 0
-        )
-
     def accept(self) -> None:
         """On accept propagate the calibration information to the main window and remove the Magnification layer"""
 
         print("Propagating magnification to table.")
         self.parent._propagate_magnification(self.a, self.b)
-        self._deactivate_calibration_layer()
+        self.parent._deactivate_calibration_layer(self.magnification_layer)
         self.parent.apply_magnification_button.setEnabled(True)
         # self.parent.mag.setEnabled(False)
         self.parent.magnification_button.setText("Update magnification")
@@ -236,5 +217,5 @@ class MagnificationDialog(QDialog):
     def reject(self) -> None:
         """On reject remove the magnification layer"""
 
-        self._deactivate_calibration_layer()
+        self.parent._deactivate_calibration_layer(self.magnification_layer)
         return super().reject()

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -167,9 +167,7 @@ class ParticleTracksWidget(QWidget):
         # Dialog pointers to reuse
         self.mag_dlg: MagnificationDialog | None = None
         self.stereoshift_dlg: StereoshiftDialog | None = None
-        self.stereoshift_isopen = False
         self.decay_angles_dlg: DecayAnglesDialog | None = None
-        self.decay_angles_isopen = False
 
         @self.viewer.layers.events.connect
         def _on_layerlist_changed(event):
@@ -479,31 +477,29 @@ class ParticleTracksWidget(QWidget):
 
     def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
-        if (self.decay_angles_dlg is not None) and (
-            self.decay_angles_isopen is True
-        ):
+        if self.decay_angles_dlg is not None:
+            self.decay_angles_dlg.show()
             self.decay_angles_dlg.raise_()
+            self._activate_calibration_layer(self.decay_angles_dlg.cal_layer)
             return self.decay_angles_dlg
         self.decay_angles_dlg = DecayAnglesDialog(self)
         self.decay_angles_dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
         self.decay_angles_dlg.move(point)
-        self.decay_angles_isopen = True
         return self.decay_angles_dlg
 
     def _on_click_stereoshift(self) -> StereoshiftDialog:
         """When the 'Calculate stereoshift' button is clicked, open stereoshift dialog."""
         # Different behaviour to the Magnification dialog, waiting for the definition of the stereoshift layer structure
-        if (self.stereoshift_dlg is not None) and (
-            self.stereoshift_isopen is True
-        ):
+        if self.stereoshift_dlg is not None:
+            self.stereoshift_dlg.show()
             self.stereoshift_dlg.raise_()
+            self._activate_calibration_layer(self.stereoshift_dlg.cal_layer)
             return self.stereoshift_dlg
         self.stereoshift_dlg = StereoshiftDialog(self)
         self.stereoshift_dlg.show()
         point = QPoint(self.pos().x() + self.width(), self.pos().y())
         self.stereoshift_dlg.move(point)
-        self.stereoshift_isopen = True
         return self.stereoshift_dlg
 
     def _on_click_load_data(self) -> None:
@@ -674,7 +670,7 @@ class ParticleTracksWidget(QWidget):
         if self.mag_dlg is not None:
             self.mag_dlg.show()
             self.mag_dlg.raise_()
-            self.mag_dlg._activate_calibration_layer()
+            self._activate_calibration_layer(self.mag_dlg.magnification_layer)
             return self.mag_dlg
         self.mag_dlg = MagnificationDialog(self)
         self.mag_dlg.show()
@@ -769,3 +765,20 @@ class ParticleTracksWidget(QWidget):
             f.writelines([particle.to_csv() for particle in self.data])
 
         napari.utils.notifications.show_info("Data saved to " + file_name)
+
+    def _activate_calibration_layer(self, layer):
+        """Show the calibration layer and move it to the top"""
+        layer.visible = True
+        # Move the calibration layer to the top
+        self.viewer.layers.move(
+            self.viewer.layers.index(layer),
+            len(self.viewer.layers),
+        )
+        self.viewer.layers.selection.active = layer
+
+    def _deactivate_calibration_layer(self, layer):
+        """Hide the calibration layer and move it to the bottom"""
+        self.viewer.layers.select_previous()
+        layer.visible = False
+        # Move the calibration layer to the bottom
+        self.viewer.layers.move(self.viewer.layers.index(layer), 0)

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -136,29 +136,6 @@ class StereoshiftDialog(QDialog):
         points = np.array(
             [
                 [
-                    origin_x + 100 / zoom_factor,
-                    origin_y - 200 / zoom_factor,
-                ],
-                [origin_x + 100 / zoom_factor, origin_y],
-                [
-                    origin_x + 100 / zoom_factor,
-                    origin_y + 200 / zoom_factor,
-                ],
-                [origin_x - 100 / zoom_factor, origin_y],
-                [
-                    origin_x - 100 / zoom_factor,
-                    origin_y + 200 / zoom_factor,
-                ],
-                [
-                    origin_x - 100 / zoom_factor,
-                    origin_y - 200 / zoom_factor,
-                ],
-            ]
-        )
-
-        points = np.array(
-            [
-                [
                     origin_x - 100 / zoom_factor,
                     origin_y - 200 / zoom_factor,
                 ],

--- a/src/cavendish_particle_tracks/_stereoshift_dialog.py
+++ b/src/cavendish_particle_tracks/_stereoshift_dialog.py
@@ -156,11 +156,35 @@ class StereoshiftDialog(QDialog):
             ]
         )
 
+        points = np.array(
+            [
+                [
+                    origin_x - 100 / zoom_factor,
+                    origin_y - 200 / zoom_factor,
+                ],
+                [
+                    origin_x + 100 / zoom_factor,
+                    origin_y - 200 / zoom_factor,
+                ],
+                [origin_x - 100 / zoom_factor, origin_y],
+                [origin_x + 100 / zoom_factor, origin_y],
+                [
+                    origin_x - 100 / zoom_factor,
+                    origin_y + 200 / zoom_factor,
+                ],
+                [
+                    origin_x + 100 / zoom_factor,
+                    origin_y + 200 / zoom_factor,
+                ],
+            ]
+        )
+
         labels = ["Reference (Front) view1", "Reference (Front) view2"]
         for item in self._fiducial_views:
             labels += [item.name]
 
-        colors = ["green", "green", "blue", "blue", "red", "red"]
+        colors = ["green", "red", "green", "red", "green", "red"]
+        symbols = ["diamond", "diamond", "cross", "cross", "disc", "disc"]
 
         text = {
             "string": labels,
@@ -181,6 +205,7 @@ class StereoshiftDialog(QDialog):
             border_width_is_relative=False,
             border_color=colors,
             face_color=colors,
+            symbol=symbols,
         )
 
         # set the edge_color mode to colormap
@@ -309,9 +334,5 @@ class StereoshiftDialog(QDialog):
 
     def reject(self) -> None:
         """On cancel remove the points_Stereoshift layer"""
-
-        # TODO: this is a problem, the layer still exists... not sure how to remove it
-        self.parent.viewer.layers.select_previous()
-        self.parent.viewer.layers.remove(self.cal_layer)
-        self.parent.stereoshift_isopen = False
+        self.parent._deactivate_calibration_layer(self.cal_layer)
         return super().reject()

--- a/tests/test_decay_angles_dialog.py
+++ b/tests/test_decay_angles_dialog.py
@@ -9,8 +9,10 @@ from pytestqt.qtbot import QtBot
         False,
     ],
 )
-def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, click_twice: bool):
-    """Smoke test for the DecayAnglesDialog."""
+def test_open_and_close_decay_angles_dialog(
+    cpt_widget, qtbot: QtBot, click_twice: bool
+):
+    """Test the expected behavior from the expected workflow:"""
     cpt_widget.particle_decays_menu.setCurrentIndex(4)
 
     # The user clicks the button (also test fringe case that they click the button again).
@@ -25,3 +27,19 @@ def test_decay_angles_dialog(cpt_widget, qtbot: QtBot, click_twice: bool):
         dialog.show()
     dialog.close()
     qtbot.waitSignals([dialog.rejected], timeout=5000)
+
+    assert not cpt_widget.decay_angles_dlg.isVisible()
+    assert "Decay Angles Tool" in cpt_widget.viewer.layers
+    assert not cpt_widget.decay_angles_dlg.cal_layer.visible
+
+    # Click again to test that the dialog opens again
+    cpt_widget._on_click_decay_angles()
+    assert cpt_widget.decay_angles_dlg.isVisible()
+    assert "Decay Angles Tool" in cpt_widget.viewer.layers
+    assert cpt_widget.decay_angles_dlg.cal_layer.visible
+
+    # close the dialog
+    cpt_widget.decay_angles_dlg.reject()
+    assert not cpt_widget.decay_angles_dlg.isVisible()
+    assert "Decay Angles Tool" in cpt_widget.viewer.layers
+    assert not cpt_widget.decay_angles_dlg.cal_layer.visible

--- a/tests/test_magnification_dialog.py
+++ b/tests/test_magnification_dialog.py
@@ -7,10 +7,25 @@ from cavendish_particle_tracks._calculate import FIDUCIAL_BACK as FB
 from cavendish_particle_tracks._calculate import FIDUCIAL_FRONT as FF
 
 
-def test_show_magnification_dialog(cpt_widget):
-    """Tests the magnification dialog is shown when the button is clicked."""
+def test_open_and_close_magnification_dialog(cpt_widget):
+    """Test the expected behavior from the expected workflow:"""
+    # open the dialog
     cpt_widget._on_click_magnification()
     assert cpt_widget.mag_dlg.isVisible()
+    assert "Magnification" in cpt_widget.viewer.layers
+    assert cpt_widget.mag_dlg.magnification_layer.visible
+
+    # close the dialog
+    cpt_widget.mag_dlg.reject()
+    assert not cpt_widget.mag_dlg.isVisible()
+    assert "Magnification" in cpt_widget.viewer.layers
+    assert not cpt_widget.mag_dlg.magnification_layer.visible
+
+    # Click again to test that the dialog opens again
+    cpt_widget._on_click_magnification()
+    assert cpt_widget.mag_dlg.isVisible()
+    assert "Magnification" in cpt_widget.viewer.layers
+    assert cpt_widget.mag_dlg.magnification_layer.visible
 
 
 @pytest.mark.parametrize("click_twice", [True, False])

--- a/tests/test_stereoshift_dialog.py
+++ b/tests/test_stereoshift_dialog.py
@@ -6,6 +6,31 @@ import pytest
 from cavendish_particle_tracks._analysis import CHAMBER_DEPTH
 
 
+def test_open_and_close_stereoshift_dialog(cpt_widget):
+    """Test the expected behavior from the expected workflow:
+
+    - Open stereoshift dialog when clicked
+    - Close the dialog
+    """
+    # open the dialog
+    cpt_widget._on_click_stereoshift()
+    assert cpt_widget.stereoshift_dlg.isVisible()
+    assert "Points_Stereoshift" in cpt_widget.viewer.layers
+    assert cpt_widget.stereoshift_dlg.cal_layer.visible
+
+    # close the dialog
+    cpt_widget.stereoshift_dlg.reject()
+    assert not cpt_widget.stereoshift_dlg.isVisible()
+    assert "Points_Stereoshift" in cpt_widget.viewer.layers
+    assert not cpt_widget.stereoshift_dlg.cal_layer.visible
+
+    # Click again to test that the dialog opens again
+    cpt_widget._on_click_stereoshift()
+    assert cpt_widget.stereoshift_dlg.isVisible()
+    assert "Points_Stereoshift" in cpt_widget.viewer.layers
+    assert cpt_widget.stereoshift_dlg.cal_layer.visible
+
+
 @pytest.mark.parametrize(
     "test_points, expected_fiducial_shift, expected_point_shift, expected_stereoshift, expected_depth, double_click",
     [


### PR DESCRIPTION
Duplicate the layer management and behaviour from the `Magnification` tool to the `Stereoshift` and `DecayAngles` tools:

- The layers are hidden when the dialog is closed
- The dialog is persisted between invocations after the first one. 