### PR TITLE
Consistent logging and warning.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contributing
 
 Contributions are very welcome.
@@ -9,7 +8,6 @@ Presumably also with the testing dependencies:
     git clone git@github.com/palvarezc/cavendish-particle-tracks.git
     cd cavendish-particle-tracks
     python -m pip install -e ".[testing]"
-
 
 Tests are run with [tox] across python 3.9, 3.10, 3.11 and 3.12.
 You can also check quickly with `pytest` if you installed the `testing` extras.
@@ -22,7 +20,15 @@ We also use `pre-commit` to ensure uniform code style.
 
 [tox]: https://tox.readthedocs.io/en/latest/
 
+We use Python's `warnings` module to communicate warnings to users.
+Warnings are forwarded by `napari`'s notification system.
+For informative messages to the user (i.e. not warnings or errors), we use `napari.utils.notifications.show_info` which is consistent with `warnings.warn`.
+
+For developer-facing logging information, we use Python's `logging`.
+This is not shown to users unless they have run `napari` in a terminal.
+
 ## Contributing documentation
+
 We are using the [myst](https://myst-parser.readthedocs.io/en/latest/index.html) markdown parser.
 
 To test contributions to the documentation, this can be built locally following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "imagecodecs",    # for opening tiff images on macos
+    "imagecodecs",              # for opening tiff images on macos
     "napari >= 0.5.2, < 0.6.0", # need >= 0.5.2 to be able to open as stack (https://github.com/napari/napari/issues/7165) and < 0.6.0 to hide layers controls
     "numpy",
-    "dask-image",     # for image loading
+    "dask-image",               # for image loading
 ]
 dynamic = ["version"]
 
@@ -110,6 +110,7 @@ select = [
     "SIM", # flake8-simplify
 ]
 ignore = [
+    "B028",   # ignore bugbear about warning stack level:- we're talking to users
     "E501",   # line too long. let black handle this
     "UP006",
     "UP007",  # type annotation. As using magicgui require runtime type annotation then we disable this.

--- a/src/cavendish_particle_tracks/_magnification_dialog.py
+++ b/src/cavendish_particle_tracks/_magnification_dialog.py
@@ -1,3 +1,5 @@
+import logging
+import warnings
 from typing import TYPE_CHECKING
 
 from napari.layers import Points
@@ -180,7 +182,7 @@ class MagnificationDialog(QDialog):
 
         # Forcing only 1 points
         if len(selected_points) != 1:
-            print("Select (only) one point to add fiducial.")
+            warnings.warn("Select (only) one point to add fiducial.")
             return [-1.0e6, -1.0e6]
 
         textbox = self.txboxes[fiducial]
@@ -195,7 +197,7 @@ class MagnificationDialog(QDialog):
         if not (
             self.f1.name and self.f2.name and self.b1.name and self.b2.name
         ):
-            print("Select fiducials to calcuate the magnification")
+            warnings.warn("Select fiducials to calcuate the magnification")
             return
 
         self.a, self.b = magnification(self.f1, self.f2, self.b1, self.b2)
@@ -206,7 +208,7 @@ class MagnificationDialog(QDialog):
     def accept(self) -> None:
         """On accept propagate the calibration information to the main window and remove the Magnification layer"""
 
-        print("Propagating magnification to table.")
+        logging.info("Propagating magnification to table.")
         self.parent._propagate_magnification(self.a, self.b)
         self.parent._deactivate_calibration_layer(self.magnification_layer)
         self.parent.apply_magnification_button.setEnabled(True)

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -7,8 +7,10 @@ for further analysis.
 """
 
 import glob
+import logging
 import os
 import pickle
+import warnings
 
 import dask.array
 import napari
@@ -196,8 +198,9 @@ class ParticleTracksWidget(QWidget):
         try:
             return int(os.environ["CPT_SHUFFLING_SEED"])
         except ValueError:
-            print(
-                f"Warning: Invalid value for CPT_SHUFFLING_SEED. Using seed value of {fallback}."
+            logging.warning(
+                "Invalid value for CPT_SHUFFLING_SEED. Using seed value of %.",
+                fallback,
             )
             return fallback
 
@@ -280,7 +283,7 @@ class ParticleTracksWidget(QWidget):
             if item == columntext:
                 return i
 
-        print("Column ", columntext, " not in the table")
+        logging.error("Column ", columntext, " not in the table")
         return -1
 
     def _on_row_selection_changed(self) -> None:
@@ -368,14 +371,10 @@ class ParticleTracksWidget(QWidget):
 
         # Forcing only 3 points
         if len(selected_points) == 0:
-            napari.utils.notifications.show_error(
-                "You have not selected any points."
-            )
+            warnings.warn("You have not selected any points.")
             return
         elif len(selected_points) != 3:
-            napari.utils.notifications.show_error(
-                "Select three points to calculate the path radius."
-            )
+            warnings.warn("Select three points to calculate the path radius.")
             return
         else:
             napari.utils.notifications.show_info(
@@ -399,7 +398,7 @@ class ParticleTracksWidget(QWidget):
 
             self.data[selected_row].rpoints = selected_points
 
-            print("calculating radius!")
+            logging.info("calculating radius!")
             rad = radius(*selected_points)
 
             self.table.setItem(
@@ -421,8 +420,8 @@ class ParticleTracksWidget(QWidget):
                 QTableWidgetItem(str(self.data[selected_row].radius_cm)),
             )
 
-            print("Modified particle ", selected_row)
-            print(self.data[selected_row])
+            logging.info("Modified particle ", selected_row)
+            logging.info(self.data[selected_row])
 
     def _on_click_length(self) -> None:
         """When the 'Calculate length' button is clicked, calculate the decay length
@@ -433,24 +432,15 @@ class ParticleTracksWidget(QWidget):
 
         # Force selection of 2 points
         if len(selected_points) == 0:
-            napari.utils.notifications.show_error(
-                "You have not selected any points."
-            )
+            warnings.warn("You have not selected any points.")
             return
         elif len(selected_points) != 2:
-            napari.utils.notifications.show_error(
-                "Select two points to calculate the decay length."
-            )
+            warnings.warn("Select two points to calculate the decay length.")
             return
         else:
             napari.utils.notifications.show_info(
                 f"Adding points to the table: {selected_points}"
             )
-
-        # Forcing only 2 points
-        if len(selected_points) != 2:
-            print("Select (only) two points to calculate the decay length.")
-            return
 
         # Assigns the points and radius to the selected row
         try:
@@ -469,7 +459,7 @@ class ParticleTracksWidget(QWidget):
                 )
             self.data[selected_row].dpoints = selected_points
 
-            print("calculating decay length!")
+            logging.info("calculating decay length!")
             declen = length(*selected_points)
             self.table.setItem(
                 selected_row,
@@ -489,8 +479,8 @@ class ParticleTracksWidget(QWidget):
                 QTableWidgetItem(str(self.data[selected_row].decay_length_cm)),
             )
 
-            print("Modified particle ", selected_row)
-            print(self.data[selected_row])
+            logging.info("Modified particle ", selected_row)
+            logging.info(self.data[selected_row])
 
     def _on_click_decay_angles(self) -> DecayAnglesDialog:
         """When the 'Calculate decay angles' buttong is clicked, open the decay angles dialog"""
@@ -657,7 +647,7 @@ class ParticleTracksWidget(QWidget):
             QTableWidgetItem(str(new_particle.magnification)),
         )
 
-        print(self.data[-1])
+        logging.info(self.data[-1])
         self.particle_decays_menu.setCurrentIndex(0)
 
     def _on_click_delete_particle(self) -> None:
@@ -738,10 +728,7 @@ class ParticleTracksWidget(QWidget):
         """
 
         if not len(self.data):
-            napari.utils.notifications.show_error(
-                "There is no data in the table to save."
-            )
-            print("There is no data in the table to save.")
+            warnings.warn("There is no data in the table to save.")
             return
 
         # setup UI

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -9,13 +9,11 @@ from qtpy.QtWidgets import QDialogButtonBox, QLineEdit, QMessageBox
 from .conftest import get_dialog
 
 
-def test_cant_save_empty(cpt_widget, capsys):
-    # click the save button
-    cpt_widget._on_click_save()
-
-    # check we see the error info
-    captured = capsys.readouterr()
-    assert "There is no data in the table to save." in captured.out
+def test_try_saving_empty_get_warning(cpt_widget):
+    with pytest.warns(
+        UserWarning, match="There is no data in the table to save."
+    ):
+        cpt_widget._on_click_save()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Would address
- #27 

`warnings.warn` the user, which goes through `napari`'s notifications. And replace `print` with `logging.info` or `logging.warning` for devs.