### PR TITLE
Remove ascii art.

### DIFF
--- a/launch_debug.py
+++ b/launch_debug.py
@@ -9,7 +9,7 @@ plugin_docking_area = "bottom"
 
 # Create the plugin
 plugin_widget = ParticleTracksWidget(
-    viewer, bypass_load_screen=False, docking_area=plugin_docking_area
+    viewer, bypass_force_load_data=False, docking_area=plugin_docking_area
 )
 
 # Add plugin to the viewer

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -313,36 +313,22 @@ class ParticleTracksWidget(QWidget):
         self, loaded: bool, bypass_load_screen: bool
     ) -> None:
         if bypass_load_screen:
-            self.buttonbox.setContentsMargins(0, 0, 0, 0)
             return
         if loaded:
-            # Set margins (left, top, right, bottom)
-            self.buttonbox.setContentsMargins(0, 0, 0, 0)
-            self.load_button.hide()
-            self.particle_decays_menu.show()
-            self.delete_particle.show()
-            self.radius_button.show()
-            self.length_button.show()
-            self.decay_angles_button.show()
-            self.stereoshift_button.show()
-            self.save_data_button.show()
-            self.magnification_button.show()
-            self.table.show()
-            self.apply_magnification_button.show()
+            self.load_button.setEnabled(False)
+            self.particle_decays_menu.setEnabled(True)
+            self.magnification_button.setEnabled(True)
         else:
-            # Set margins (left, top, right, bottom)
-            self.buttonbox.setContentsMargins(200, 0, 200, 0)
-            self.load_button.show()
-            self.particle_decays_menu.hide()
-            self.delete_particle.hide()
-            self.radius_button.hide()
-            self.length_button.hide()
-            self.decay_angles_button.hide()
-            self.stereoshift_button.hide()
-            self.save_data_button.hide()
-            self.magnification_button.hide()
-            self.table.hide()
-            self.apply_magnification_button.hide()
+            self.load_button.setEnabled(True)
+            self.particle_decays_menu.setEnabled(False)
+            self.delete_particle.setEnabled(False)
+            self.radius_button.setEnabled(False)
+            self.length_button.setEnabled(False)
+            self.decay_angles_button.setEnabled(False)
+            self.stereoshift_button.setEnabled(False)
+            self.save_data_button.setEnabled(False)
+            self.magnification_button.setEnabled(False)
+            self.apply_magnification_button.setEnabled(False)
 
     def _on_click_radius(self) -> None:
         """When the 'Calculate radius' button is clicked, calculate the radius

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -46,12 +46,13 @@ class ParticleTracksWidget(QWidget):
     def __init__(
         self,
         napari_viewer: napari.Viewer,
-        bypass_load_screen: bool = False,
+        bypass_force_load_data: bool = False,
         docking_area: str = "right",
     ):
         super().__init__()
         self.viewer: napari.Viewer = napari_viewer
-        self.bypass_load_screen = bypass_load_screen
+        # In normal operation: the user is forced to load data before they can do anything.
+        self.bypass_force_load_data = bypass_force_load_data
         self.docking_area = docking_area
 
         self.shuffling_seed = self._get_shuffling_seed()
@@ -142,7 +143,7 @@ class ParticleTracksWidget(QWidget):
             # Disable viewer buttons, prevents accidental crash due to viewing image stack side on.
             self.viewer.window._qt_viewer.viewerButtons.hide()
 
-        self.set_UI_image_loaded(False, self.bypass_load_screen)
+        self.set_UI_image_loaded(False, self.bypass_force_load_data)
         # TODO: include self.stsh in the logic, depending on what it actually ends up doing
 
         # Data analysis
@@ -281,7 +282,7 @@ class ParticleTracksWidget(QWidget):
             if layer.name == "Particle Tracks":
                 images_imported = True
                 break
-        self.set_UI_image_loaded(images_imported, self.bypass_load_screen)
+        self.set_UI_image_loaded(images_imported, self.bypass_force_load_data)
         try:
             selected_row = self._get_selected_row()
             self.save_data_button.setEnabled(True)

--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -14,15 +14,13 @@ import dask.array
 import napari
 import numpy as np
 from dask_image.imread import imread
-from qtpy.QtCore import QPoint, Qt
-from qtpy.QtGui import QFont
+from qtpy.QtCore import QPoint
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QComboBox,
     QFileDialog,
     QGridLayout,
     QHBoxLayout,
-    QLabel,
     QMessageBox,
     QPushButton,
     QRadioButton,
@@ -54,8 +52,6 @@ class ParticleTracksWidget(QWidget):
         self.viewer: napari.Viewer = napari_viewer
         self.bypass_load_screen = bypass_load_screen
         self.docking_area = docking_area
-        if self.docking_area != "bottom":
-            self.bypass_load_screen = True
 
         self.shuffling_seed = self._get_shuffling_seed()
 
@@ -103,21 +99,6 @@ class ParticleTracksWidget(QWidget):
         # self.viewer.mouse_press.callbacks.connect(self._on_mouse_press)
         # self.viewer.events.mouse_press(self._on_mouse_click)
 
-        # layout
-        self.intro_text = QLabel(
-            r"""
-   _____                          _ _     _       _____           _   _      _        _______             _
-  / ____|                        | (_)   | |     |  __ \         | | (_)    | |      |__   __|           | |
- | |     __ ___   _____ _ __   __| |_ ___| |__   | |__) |_ _ _ __| |_ _  ___| | ___     | |_ __ __ _  ___| | _____
- | |    / _` \ \ / / _ \ '_ \ / _` | / __| '_ \  |  ___/ _` | '__| __| |/ __| |/ _ \    | | '__/ _` |/ __| |/ / __|
- | |___| (_| |\ V /  __/ | | | (_| | \__ \ | | | | |  | (_| | |  | |_| | (__| |  __/    | | | | (_| | (__|   <\__ \
-  \_____\__,_| \_/ \___|_| |_|\__,_|_|___/_| |_| |_|   \__,_|_|   \__|_|\___|_|\___|    |_|_|  \__,_|\___|_|\_\___/
-
-"""
-        )
-        self.intro_text.setFont(QFont("Lucida Console", 5))
-        self.intro_text.setTextFormat(Qt.TextFormat.PlainText)
-
         if self.docking_area == "bottom":
             self.buttonbox = QGridLayout()
             self.buttonbox.addWidget(self.load_button, 0, 0)
@@ -133,7 +114,6 @@ class ParticleTracksWidget(QWidget):
 
             layout_outer = QHBoxLayout()
             self.setLayout(layout_outer)
-            self.layout().addWidget(self.intro_text)
             layout_outer.addLayout(self.buttonbox)
             self.layout().addWidget(self.table)
 
@@ -326,12 +306,10 @@ class ParticleTracksWidget(QWidget):
     ) -> None:
         if bypass_load_screen:
             self.buttonbox.setContentsMargins(0, 0, 0, 0)
-            self.intro_text.hide()
             return
         if loaded:
             # Set margins (left, top, right, bottom)
             self.buttonbox.setContentsMargins(0, 0, 0, 0)
-            self.intro_text.hide()
             self.load_button.hide()
             self.particle_decays_menu.show()
             self.delete_particle.show()
@@ -346,7 +324,6 @@ class ParticleTracksWidget(QWidget):
         else:
             # Set margins (left, top, right, bottom)
             self.buttonbox.setContentsMargins(200, 0, 200, 0)
-            self.intro_text.show()
             self.load_button.show()
             self.particle_decays_menu.hide()
             self.delete_particle.hide()

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -31,11 +31,21 @@ def test_open_widget(make_napari_viewer, bypass_load_screen, docking_area):
 
     # Check the widget behavior before and after loading the data
     if docking_area == "bottom" and bypass_load_screen is False:
-        assert widget.intro_text.isVisible() is True
+        assert widget.particle_decays_menu.isVisible() is False
+        assert widget.radius_button.isVisible() is False
+        assert widget.delete_particle.isVisible() is False
+        assert widget.length_button.isVisible() is False
+        assert widget.decay_angles_button.isVisible() is False
+
         widget.viewer.add_image(
             np.random.random((100, 100)), name="Particle Tracks"
         )
-        assert widget.intro_text.isVisible() is False
+
+        assert widget.particle_decays_menu.isVisible() is True
+        assert widget.radius_button.isVisible() is True
+        assert widget.delete_particle.isVisible() is True
+        assert widget.length_button.isVisible() is True
+        assert widget.decay_angles_button.isVisible() is True
 
 
 def test_calculate_radius_ui(

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -15,37 +15,43 @@ from cavendish_particle_tracks._main_widget import ParticleTracksWidget
 from .conftest import get_dialog
 
 
-@pytest.mark.parametrize("bypass_load_screen", [True, False])
+@pytest.mark.parametrize("bypass", [True, False])
 @pytest.mark.parametrize("docking_area", ["left", "bottom"])
-def test_open_widget(make_napari_viewer, bypass_load_screen, docking_area):
+def test_open_widget(make_napari_viewer, bypass, docking_area):
     """Test the opening of the widget"""
     viewer = make_napari_viewer()
     widget = ParticleTracksWidget(
         napari_viewer=viewer,
-        bypass_load_screen=bypass_load_screen,
+        bypass_force_load_data=bypass,
         docking_area=docking_area,
     )
     assert widget.isVisible() is False
     widget.show()
     assert widget.isVisible() is True
 
+    if bypass:
+        return
+
     # Check the widget behavior before and after loading the data
-    if docking_area == "bottom" and bypass_load_screen is False:
-        assert widget.particle_decays_menu.isVisible() is False
-        assert widget.radius_button.isVisible() is False
-        assert widget.delete_particle.isVisible() is False
-        assert widget.length_button.isVisible() is False
-        assert widget.decay_angles_button.isVisible() is False
+    assert widget.particle_decays_menu.isEnabled() is False
+    assert widget.radius_button.isEnabled() is False
+    assert widget.delete_particle.isEnabled() is False
+    assert widget.length_button.isEnabled() is False
+    assert widget.stereoshift_button.isEnabled() is False
+    assert widget.magnification_button.isEnabled() is False
+    assert widget.decay_angles_button.isEnabled() is False
 
-        widget.viewer.add_image(
-            np.random.random((100, 100)), name="Particle Tracks"
-        )
+    widget.viewer.add_image(
+        np.random.random((100, 100)), name="Particle Tracks"
+    )
 
-        assert widget.particle_decays_menu.isVisible() is True
-        assert widget.radius_button.isVisible() is True
-        assert widget.delete_particle.isVisible() is True
-        assert widget.length_button.isVisible() is True
-        assert widget.decay_angles_button.isVisible() is True
+    assert widget.particle_decays_menu.isEnabled() is True
+    assert widget.radius_button.isEnabled() is False
+    assert widget.delete_particle.isEnabled() is False
+    assert widget.length_button.isEnabled() is False
+    assert widget.stereoshift_button.isEnabled() is False
+    assert widget.magnification_button.isEnabled() is True
+    assert widget.decay_angles_button.isEnabled() is False
 
 
 def test_calculate_radius_ui(


### PR DESCRIPTION
As argued for in the body of 
- #170 

I think this makes things nicer and more usable. Sorry for being boring!


In right-docked:

<img width="1256" alt="Screenshot 2024-09-29 at 13 15 44" src="https://github.com/user-attachments/assets/56f0a568-0655-4c6f-b565-b859ebc15fe2">

In bottom-docked:
<img width="1256" alt="Screenshot 2024-09-29 at 13 15 28" src="https://github.com/user-attachments/assets/f6366838-e0df-425f-af4c-e3da5fa6be15">

