### PR TITLE
Small changes to the table

### DIFF
--- a/src/cavendish_particle_tracks/_main_widget.py
+++ b/src/cavendish_particle_tracks/_main_widget.py
@@ -611,12 +611,17 @@ class ParticleTracksWidget(QWidget):
         self.table.setItem(
             self.table.rowCount() - 1,
             self._get_table_column_index("index"),
-            QTableWidgetItem(new_particle.index),
+            QTableWidgetItem(str(new_particle.index)),
         )
         self.table.setItem(
             self.table.rowCount() - 1,
             self._get_table_column_index("name"),
             QTableWidgetItem(new_particle.name),
+        )
+        self.table.setItem(
+            self.table.rowCount() - 1,
+            self._get_table_column_index("event_number"),
+            QTableWidgetItem(str(new_particle.event_number)),
         )
         self.table.setItem(
             self.table.rowCount() - 1,
@@ -680,16 +685,22 @@ class ParticleTracksWidget(QWidget):
                 self._get_table_column_index("magnification"),
                 QTableWidgetItem(str(self.data[i].magnification)),
             )
-            self.table.setItem(
-                i,
-                self._get_table_column_index("radius_cm"),
-                QTableWidgetItem(str(self.data[i].radius_cm)),
-            )
-            self.table.setItem(
-                i,
-                self._get_table_column_index("decay_length_cm"),
-                QTableWidgetItem(str(self.data[i].decay_length_cm)),
-            )
+            # if the radius has been computed before, show the calibrated value
+            if self.table.item(i, self._get_table_column_index("radius_px")) is not None:
+                self.table.setItem(
+                    i,
+                    self._get_table_column_index("radius_cm"),
+                    QTableWidgetItem(str(self.data[i].radius_cm)),
+                )
+            if (
+                self.table.item(i, self._get_table_column_index("decay_length_px"))
+                is not None
+            ):
+                self.table.setItem(
+                    i,
+                    self._get_table_column_index("decay_length_cm"),
+                    QTableWidgetItem(str(self.data[i].decay_length_cm)),
+                )
 
     def _on_click_save(self) -> None:
         """Save list of particles to csv file.

--- a/src/cavendish_particle_tracks/analysis.py
+++ b/src/cavendish_particle_tracks/analysis.py
@@ -81,6 +81,8 @@ class StereoshiftInfo:
 class ParticleDecay:
     name: str = ""
     index: int = 0
+    event_number: int = -1
+    view_number: int = -1
     _r1: list[float] = field(default_factory=lambda: [0.0, 0.0])
     _r2: list[float] = field(default_factory=lambda: [0.0, 0.0])
     _r3: list[float] = field(default_factory=lambda: [0.0, 0.0])
@@ -100,12 +102,11 @@ class ParticleDecay:
     )
     phi_proton: float = -100
     phi_pion: float = -100
-    event_number: int = -1
-    view_number: int = -1
 
     def vars_to_show(self, calibrated=False):
         if calibrated:
             return [
+                "event_number",
                 "name",
                 "radius_cm",
                 "decay_length_cm",
@@ -117,6 +118,7 @@ class ParticleDecay:
             ]
         else:
             return [
+                "event_number",
                 "name",
                 "radius_px",
                 "decay_length_px",

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -142,6 +142,30 @@ def test_load_data(
         assert cpt_widget.viewer.layers[data_layer_index].name == IMAGE_LAYER_NAME
         assert cpt_widget.viewer.layers[data_layer_index].ndim == 4
         assert cpt_widget.viewer.dims.current_step[1] == 0
+
+        # Add a new particle and check the event_number is recorded correctly
+        # Move to event 1
+        cpt_widget.viewer.dims.set_current_step(1, 1)
+        # Add a new particle
+        cpt_widget.particle_decays_menu.setCurrentIndex(1)
+        assert cpt_widget.table.rowCount() == 1
+        assert cpt_widget.data[0].event_number == 1, "The event number should be 1"
+        assert (
+            cpt_widget.table.item(
+                0, cpt_widget._get_table_column_index("event_number")
+            ).text()
+            == "1"
+        )
+
+        # Check that apply_magnification does not show anything in the table
+        cpt_widget._apply_magnification()
+        assert not cpt_widget.table.item(
+            0, cpt_widget._get_table_column_index("radius_cm")
+        ), "The calibrated radius should not be shown in the table"
+        assert not cpt_widget.table.item(
+            0, cpt_widget._get_table_column_index("decay_length_cm")
+        ), "The calibrated radius should not be shown in the table"
+
     else:
         # def capture_msgbox():
         #    for widget in QApplication.topLevelWidgets():


### PR DESCRIPTION
- Show `event_number` on the table, for better traceability of the events.
- Fix a small bug, where rubbish was shown under `radius_cm` and `decay_length_cm` when magnification is applied, but before these quantities were computed.