### PR TITLE
Python 3.13.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ write_to = "src/cavendish_particle_tracks/_version.py"
 
 [tool.black]
 line-length = 90
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 
 [tool.ruff]
@@ -152,6 +152,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Even of we/`napari` don't officially support Python 3.13, it doesn't hurt to test.